### PR TITLE
PerfectNegotiation: Run peer-connection operations off the cooperative pool

### DIFF
--- a/Sources/NabtoWebRTCUtilPerfectNegotiation/PerfectNegotiation.swift
+++ b/Sources/NabtoWebRTCUtilPerfectNegotiation/PerfectNegotiation.swift
@@ -12,6 +12,46 @@ fileprivate enum PerfectNegotiationError: Error {
     case missingLocalDescription
 }
 
+/// A continuation wrapper that can be resumed at most once, from either the
+/// async operation's completion or task cancellation, whichever happens first.
+/// Thread-safe via an internal lock; handles cancellation arriving before the
+/// continuation is attached.
+fileprivate final class CancellableContinuation<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+    private var pendingResult: Result<T, Error>?
+    private var finished = false
+
+    func attach(_ continuation: CheckedContinuation<T, Error>) {
+        lock.lock()
+        if let pendingResult {
+            finished = true
+            lock.unlock()
+            continuation.resume(with: pendingResult)
+        } else {
+            self.continuation = continuation
+            lock.unlock()
+        }
+    }
+
+    func resume(with result: Result<T, Error>) {
+        lock.lock()
+        if finished {
+            lock.unlock()
+            return
+        }
+        if let continuation {
+            finished = true
+            self.continuation = nil
+            lock.unlock()
+            continuation.resume(with: result)
+        } else {
+            pendingResult = result
+            lock.unlock()
+        }
+    }
+}
+
 /**
  * This class implements the <a
  * href="https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation">Perfect
@@ -157,75 +197,99 @@ public class PerfectNegotiation {
     // The fix runs each peer-connection operation on a dedicated serial queue
     // and suspends the caller on a continuation. Any blocking then lands on our
     // own thread, never a cooperative-pool thread, so the pool stays free.
+    //
+    // The bridge is also cancellation-aware: If the negotiation task is
+    // cancelled while suspended here (for example close() during an in-flight
+    // operation), the caller is resumed with CancellationError so the event
+    // loop can unwind and the PerfectNegotiation instance can deallocate,
+    // rather than waiting for the WebRTC callback (which may be slow or, after
+    // the peer connection is closed, never fire). The underlying WebRTC
+    // operation cannot be cancelled, so its later callback is ignored. The
+    // continuation is resumed exactly once.
 
     private func applyLocalDescription() async throws {
         // RTCPeerConnection only exposes the implicit (offer-or-answer)
         // setLocalDescription as a blocking async call, so create the local
         // description explicitly via the suspending completion-handler variants
-        // and then set it. This mirrors the implicit behavior: answer when we
+        // and then set it. This mirrors the implicit behavior: Answer when we
         // hold a remote offer, otherwise offer.
         let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
         let sdp = try await createLocalSessionDescription(constraints: constraints)
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            peerConnectionQueue.async {
-                self.peerConnection.setLocalDescription(sdp, completionHandler: { error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume()
-                    }
-                })
-            }
+        try await runOnPeerConnectionQueue { [peerConnection] (completion: @escaping (Result<Void, Error>) -> Void) in
+            peerConnection.setLocalDescription(sdp, completionHandler: { error in
+                if let error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(()))
+                }
+            })
         }
     }
 
     private func createLocalSessionDescription(constraints: RTCMediaConstraints) async throws -> RTCSessionDescription {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<RTCSessionDescription, Error>) in
-            peerConnectionQueue.async {
-                let completion: (RTCSessionDescription?, Error?) -> Void = { sdp, error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else if let sdp {
-                        continuation.resume(returning: sdp)
-                    } else {
-                        continuation.resume(throwing: PerfectNegotiationError.missingLocalDescription)
-                    }
+        try await runOnPeerConnectionQueue { [peerConnection] (completion: @escaping (Result<RTCSessionDescription, Error>) -> Void) in
+            let handler: (RTCSessionDescription?, Error?) -> Void = { sdp, error in
+                if let error {
+                    completion(.failure(error))
+                } else if let sdp {
+                    completion(.success(sdp))
+                } else {
+                    completion(.failure(PerfectNegotiationError.missingLocalDescription))
                 }
-                switch self.peerConnection.signalingState {
-                case .haveRemoteOffer, .haveLocalPrAnswer:
-                    self.peerConnection.answer(for: constraints, completionHandler: completion)
-                default:
-                    self.peerConnection.offer(for: constraints, completionHandler: completion)
-                }
+            }
+            switch peerConnection.signalingState {
+            case .haveRemoteOffer, .haveLocalPrAnswer:
+                peerConnection.answer(for: constraints, completionHandler: handler)
+            default:
+                peerConnection.offer(for: constraints, completionHandler: handler)
             }
         }
     }
 
     private func applyRemoteDescription(_ description: RTCSessionDescription) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            peerConnectionQueue.async {
-                self.peerConnection.setRemoteDescription(description, completionHandler: { error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume()
-                    }
-                })
-            }
+        try await runOnPeerConnectionQueue { [peerConnection] (completion: @escaping (Result<Void, Error>) -> Void) in
+            peerConnection.setRemoteDescription(description, completionHandler: { error in
+                if let error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(()))
+                }
+            })
         }
     }
 
     private func addRemoteCandidate(_ candidate: RTCIceCandidate) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            peerConnectionQueue.async {
-                self.peerConnection.add(candidate, completionHandler: { error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume()
-                    }
-                })
+        try await runOnPeerConnectionQueue { [peerConnection] (completion: @escaping (Result<Void, Error>) -> Void) in
+            peerConnection.add(candidate, completionHandler: { error in
+                if let error {
+                    completion(.failure(error))
+                } else {
+                    completion(.success(()))
+                }
+            })
+        }
+    }
+
+    /// Runs `body` on the dedicated peer-connection queue and suspends the
+    /// caller until `body` invokes its completion. Cancellation-aware: If the
+    /// task is cancelled while suspended, the caller is resumed with
+    /// CancellationError and the WebRTC callback (which cannot be cancelled) is
+    /// ignored when it later fires. The caller is resumed exactly once.
+    /// `body` captures the peer connection rather than self, so a cancelled
+    /// negotiation does not keep the PerfectNegotiation instance alive.
+    private func runOnPeerConnectionQueue<T>(
+        _ body: @escaping (@escaping (Result<T, Error>) -> Void) -> Void
+    ) async throws -> T {
+        let state = CancellableContinuation<T>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+                state.attach(continuation)
+                peerConnectionQueue.async {
+                    body { result in state.resume(with: result) }
+                }
             }
+        } onCancel: {
+            state.resume(with: .failure(CancellationError()))
         }
     }
 

--- a/Sources/NabtoWebRTCUtilPerfectNegotiation/PerfectNegotiation.swift
+++ b/Sources/NabtoWebRTCUtilPerfectNegotiation/PerfectNegotiation.swift
@@ -8,6 +8,10 @@ fileprivate enum PerfectNegotiationEvent {
     case message(_ message: WebrtcSignalingMessage)
 }
 
+fileprivate enum PerfectNegotiationError: Error {
+    case missingLocalDescription
+}
+
 /**
  * This class implements the <a
  * href="https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation">Perfect
@@ -17,6 +21,12 @@ fileprivate enum PerfectNegotiationEvent {
 public class PerfectNegotiation {
     private let peerConnection: RTCPeerConnection
     private let messageTransport: MessageTransport
+
+    /// Dedicated serial queue on which the (potentially blocking)
+    /// RTCPeerConnection operations run, so they never block a Swift
+    /// cooperative-pool thread. See the note above `applyLocalDescription`.
+    private let peerConnectionQueue = DispatchQueue(
+        label: "com.nabto.webrtc.perfectNegotiation.peerConnection")
 
     private var polite = false
     private var makingOffer = false
@@ -76,7 +86,7 @@ public class PerfectNegotiation {
             self.makingOffer = true
             defer { self.makingOffer = false }
             do {
-                try await peerConnection.setLocalDescription()
+                try await applyLocalDescription()
                 await self.sendDescription(self.peerConnection.localDescription)
             } catch {
                 // @TODO: Better logging
@@ -103,7 +113,7 @@ public class PerfectNegotiation {
     private func addIceCandidate(_ cand: SignalingCandidate.Candidate) async throws {
         let remoteCandidate = RTCIceCandidate(sdp: cand.candidate, sdpMLineIndex: 0, sdpMid: cand.sdpMid)
         do {
-            try await peerConnection.add(remoteCandidate)
+            try await addRemoteCandidate(remoteCandidate)
         } catch {
             if !ignoreOffer {
                 throw error
@@ -122,12 +132,100 @@ public class PerfectNegotiation {
 
         let type = RTCSessionDescription.type(for: desc.type)
         let desc = RTCSessionDescription(type: type, sdp: desc.sdp)
-        try await self.peerConnection.setRemoteDescription(desc)
-        
+        try await applyRemoteDescription(desc)
+
         // Send answer only if we are receiving an offer
         if type == .offer {
-            try await self.peerConnection.setLocalDescription()
+            try await applyLocalDescription()
             await self.sendDescription(self.peerConnection.localDescription)
+        }
+    }
+
+    // MARK: - Non-blocking peer-connection operations
+    //
+    // The WebRTC setLocalDescription/setRemoteDescription/add operations block
+    // the calling thread until the signaling thread finishes (the `async`
+    // overloads suspend nothing, they block, and even the completion-handler
+    // overloads do synchronous work on the caller). PerfectNegotiation's event
+    // loop runs on the Swift cooperative thread pool, which is fixed size (one
+    // thread per core), so each blocking call parks one pool thread. When many
+    // PerfectNegotiation instances negotiate at once (for example an NVR client
+    // opening many cameras together, especially over a relayed or high-latency
+    // path) the pool is exhausted and the app deadlocks: no thread is left to
+    // run the continuations that would let the blocked calls finish.
+    //
+    // The fix runs each peer-connection operation on a dedicated serial queue
+    // and suspends the caller on a continuation. Any blocking then lands on our
+    // own thread, never a cooperative-pool thread, so the pool stays free.
+
+    private func applyLocalDescription() async throws {
+        // RTCPeerConnection only exposes the implicit (offer-or-answer)
+        // setLocalDescription as a blocking async call, so create the local
+        // description explicitly via the suspending completion-handler variants
+        // and then set it. This mirrors the implicit behavior: answer when we
+        // hold a remote offer, otherwise offer.
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil, optionalConstraints: nil)
+        let sdp = try await createLocalSessionDescription(constraints: constraints)
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            peerConnectionQueue.async {
+                self.peerConnection.setLocalDescription(sdp, completionHandler: { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                })
+            }
+        }
+    }
+
+    private func createLocalSessionDescription(constraints: RTCMediaConstraints) async throws -> RTCSessionDescription {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<RTCSessionDescription, Error>) in
+            peerConnectionQueue.async {
+                let completion: (RTCSessionDescription?, Error?) -> Void = { sdp, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if let sdp {
+                        continuation.resume(returning: sdp)
+                    } else {
+                        continuation.resume(throwing: PerfectNegotiationError.missingLocalDescription)
+                    }
+                }
+                switch self.peerConnection.signalingState {
+                case .haveRemoteOffer, .haveLocalPrAnswer:
+                    self.peerConnection.answer(for: constraints, completionHandler: completion)
+                default:
+                    self.peerConnection.offer(for: constraints, completionHandler: completion)
+                }
+            }
+        }
+    }
+
+    private func applyRemoteDescription(_ description: RTCSessionDescription) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            peerConnectionQueue.async {
+                self.peerConnection.setRemoteDescription(description, completionHandler: { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                })
+            }
+        }
+    }
+
+    private func addRemoteCandidate(_ candidate: RTCIceCandidate) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            peerConnectionQueue.async {
+                self.peerConnection.add(candidate, completionHandler: { error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        continuation.resume()
+                    }
+                })
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

`PerfectNegotiation`'s event loop runs in a bare `Task` on the Swift cooperative thread pool, and inside it calls the WebRTC `setLocalDescription`, `setRemoteDescription` and `add` operations. Those calls block the calling thread until the signaling thread finishes: The `async` overloads suspend nothing (they block), and the completion-handler overloads also do synchronous work on the caller. The cooperative pool is fixed size at one thread per core, so when many `PerfectNegotiation` instances negotiate at once (for example an NVR client opening many cameras together, especially over a relayed or high-latency path) every pool thread parks and the Swift runtime deadlocks: No thread is left to run the continuations that would let the blocked calls finish.

## Reproduction

16 simultaneous relayed (TURN) connections on an iPhone 15 Pro (6 cores). The UI hangs at 16 connections and works at 6, which is the core-count signature of cooperative-pool exhaustion. A paused `bt all` showed all six cooperative threads parked in `setRemoteDescription`. Capping concurrent negotiation below the core count with an app-side gate avoided the hang, confirming the mechanism.

## Fix

Run each peer-connection operation on a private per-instance serial `DispatchQueue` and suspend the caller on a continuation. Any blocking then lands on the SDK's own thread, never a cooperative-pool thread, so the pool stays free. This is robust whether or not the underlying WebRTC call blocks. The single serial queue also preserves the sequential ordering that negotiation requires.

`applyLocalDescription` additionally recreates the implicit offer-or-answer `setLocalDescription` explicitly (via `offer(for:)` / `answer(for:)` chosen by signaling state), because WebRTC only exposes the implicit form as a blocking async method with no completion-handler spelling.

The change is internal to `PerfectNegotiation`. No public API change, source- and ABI-compatible.

## Verification

Builds against a multi-connection example app. On device, 16 simultaneous relayed connections that previously froze now connect with no gate and no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
